### PR TITLE
feat: add route change event name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ You can use a custom cookie name if you need to!
 
 Data layer name
 
+#### `routeChangeEvent`
+
+The name of the event which will be triggered when route changes
+Defaults to `gatsbyRouteChange`
+
 #### `gtmAuth`
 
 Google Tag Manager environment auth string

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Data layer to be set before GTM is loaded. Should be an object or a function tha
 
 Out of the box this plugin will simply load Google Tag Manager on the initial page/app load. It’s up to you to fire tags based on changes in your app.
 
-This plugin will fire a new event called `gatsbyRouteChange` on Gatsby's `onRouteUpdate` (only if the consent was given by a visitor). To record this in Google Tag Manager, we will need to add a trigger to the desired tag to listen for the event:
+This plugin will fire a new event called `gatsbyRouteChange` (by default) on Gatsby's `onRouteUpdate` (only if the consent was given by a visitor). To record this in Google Tag Manager, we will need to add a trigger to the desired tag to listen for the event:
 
 In order to do that, go to _Tags_. Under _Triggering_ click the pencil icon, then the ”+” button to add a new trigger. In the _Choose a trigger_ window, click on the ”+” button again. Choose the trigger type by clicking the pencil button and clicking _Custom event_. For event name, enter `gatsbyRouteChange`. This tag will now catch every route change in Gatsby, and you can add Google tag services as you wish to it.
 

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -7,6 +7,7 @@ export default {
   googleTagManager: {
     cookieName: `gatsby-gdpr-google-tagmanager`,
     dataLayerName: `dataLayer`,
+    routeChangeEvent: `gatsbyRouteChange`,
   },
   facebookPixel: {
     cookieName: `gatsby-gdpr-facebook-pixel`,

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -71,7 +71,8 @@ export const onRouteUpdate = ({ location }, pluginOptions = {}) => {
           : window.dataLayer
 
         if (typeof data === `object`) {
-          data.push({ event: `gatsbyRouteChange` })
+          const eventName = options.googleTagManager.routeChangeEvent || `gatsbyRouteChange`
+          data.push({ event: eventName })
         }
       }, 50)
     }


### PR DESCRIPTION
Some applications may need a custom event to be triggered on route change; I added the option to the plugin.