### PR TITLE
Fix: minor typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This gatsby plugin now supports initializing and tracking right after a user acc
 import { useLocation } from "@reach/router" // this helps tracking the location
 import { initializeAndTrack } from 'gatsby-plugin-gdpr-cookies'
 ```
-Then you can execute `initializeAndTrack(location)` in your cookie banner callback. This will initialize the the plugin with your options from the `gatsby-config.js` and than starts tracking the user based on the cookies/services are accepted.
+Then you can execute `initializeAndTrack(location)` in your cookie banner callback. This will initialize the plugin with your options from the `gatsby-config.js` and then starts tracking the user based on the cookies/services are accepted.
 
 ```javascript
 // in your cookie banner


### PR DESCRIPTION
I've detected some minor typos in your `README.md`. The purpose of this PR is to fix them in order to help more people using your plugin.