### PR TITLE
Modified for addition of LinkedIn insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ module.exports = {
           hjsv: 'YOUR_HOTJAR_SNIPPET_VERSION',
           cookieName: 'gatsby-gdpr-hotjar', // default
         },
+        linkedin: {
+          trackingId: 'YOUR_LINKEDIN_TRACKING_ID', // leave empty if you want to disable the tracker
+          cookieName: 'gatsby-gdpr-linked-in', // default
+        },
         // defines the environments where the tracking should be available  - default is ["production"]
         environments: ['production', 'development']
       },
@@ -193,6 +197,16 @@ You can find the base url within your inbox.
 #### `websiteToken`
 
 You can find the website token within your inbox.
+
+#### `cookieName`
+
+You can use a custom cookie name if you need to!
+
+### LinkedIn
+
+#### `trackingId`
+
+Here you place your LinkedIn tracking ID.
 
 #### `cookieName`
 

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -21,5 +21,8 @@ export const defaultOptions = {
   },
   chatwoot: {
     cookieName: 'gatsby-gdpr-chatwoot'
+  },
+  linkedin: {
+    cookieName: 'gatsby-gdpr-linkedin'
   }
 }

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -10,12 +10,14 @@ export const onClientEntry = (_, pluginOptions = {}) => {
   window.gatsbyPluginGDPRCookiesTikTokPixelAdded = false
   window.gatsbyPluginGDPRCookiesHotjarAdded = false
   window.gatsbyPluginGDPRCookiesChatwootAdded = false
+  window.gatsbyPluginGDPRCookiesLinkedinAdded = false
 
   window.gatsbyPluginGDPRCookiesGoogleAnalyticsInitialized = false
   window.gatsbyPluginGDPRCookiesGoogleTagManagerInitialized = false
   window.gatsbyPluginGDPRCookiesFacebookPixelInitialized = false
   window.gatsbyPluginGDPRCookiesTikTokPixelInitialized = false
   window.gatsbyPluginGDPRCookiesHotjarInitialized = false
+  window.gatsbyPluginGDPRCookiesLinkedinInitialized = false
 
   // google tag manager setup
   const { googleTagManager } = pluginOptions

--- a/src/helper.js
+++ b/src/helper.js
@@ -26,6 +26,10 @@ exports.validChatwootConfig = options =>
   options.websiteToken &&
   options.websiteToken.trim() !== ``
 
+exports.validLinkedinTrackingId = options =>
+  options.trackingId &&
+  options.trackingId.trim() !== ``  
+
 exports.getCookie = name => {
   var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
   return v ? v[2] : null;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ const {
   initializeAndTrackFacebookPixel,
   initializeAndTrackTikTokPixel,
   initializeAndTrackHotjar,
-  initializeChatwoot
+  initializeChatwoot,
+  initializeLinkedin
 } = require('./services')
 
 const { isEnvironmentValid } = require('./helper')
@@ -22,6 +23,7 @@ exports.initializeAndTrack = (location) => {
       initializeAndTrackTikTokPixel(options.tikTokPixel)
       initializeAndTrackHotjar(options.hotjar)
       initializeChatwoot(options.chatwoot)
+      initializeLinkedin(options.linkedin)
     }
   }
 }

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -5,6 +5,7 @@ const {
   validTikTokPixelId,
   validHotjarId,
   validChatwootConfig,
+  validLinkedinTrackingId,
   getCookie
 } = require('../helper')
 
@@ -41,6 +42,11 @@ const {
 const {
   addChatwoot
 } = require('./chatwoot')
+
+const {
+  addLinkedin,
+  initializeLinkedin
+} = require('./linkedin')
 
 exports.initializeAndTrackGoogleAnalytics = (options, location) => {
   if (
@@ -112,6 +118,19 @@ exports.initializeAndTrackHotjar = (options) => {
       if (status) {
         initializeHotjar(options)
         trackHotjar(options)
+      }
+    })
+  }
+}
+
+exports.initializeLinkedin = (options) => {
+  if (
+    getCookie(options.cookieName) === `true` &&
+    validLinkedinTrackingId(options)
+  ) {
+    addLinkedin(options).then((status) => {
+      if (status) {
+        initializeLinkedin(options)
       }
     })
   }

--- a/src/services/linkedin.js
+++ b/src/services/linkedin.js
@@ -1,0 +1,40 @@
+const {
+  validLinkedinTrackingId,
+  getCookie
+} = require('../helper')
+
+exports.addLinkedin = (options) => {
+  return new Promise((resolve, reject) => {
+    if (window.gatsbyPluginGDPRCookiesLinkedinAdded) return resolve(true)
+
+    /* eslint-disable */
+      // LINKED IN SPECIFIC CODE HERE
+      _linkedin_partner_id = options.trackingId;
+      window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || []; 
+      window._linkedin_data_partner_ids.push(_linkedin_partner_id); 
+    /* eslint-enable */
+
+    window.gatsbyPluginGDPRCookiesLinkedinAdded = true
+
+    resolve(true)
+  })
+}
+
+exports.initializeLinkedin = (options) => {
+  if (
+    !window.gatsbyPluginGDPRCookiesLinkedinInitialized &&
+    getCookie(options.cookieName) === `true` &&
+    validLinkedinTrackingId(options)
+  ) {
+    // (function(){
+      var s = document.getElementsByTagName("script")[0]; 
+      var b = document.createElement("script"); 
+      b.type = "text/javascript";
+      b.async = true; 
+      b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js"; 
+      s.parentNode.insertBefore(b, s);
+    // })();
+
+    window.gatsbyPluginGDPRCookiesLinkedinInitialized = true
+  }
+}


### PR DESCRIPTION
I needed to account for the LinkedIn Insights tracking tag recently, so I integrated it as another source.

What is in this pull request:
- The addition of LinkedIn as one of the main source.
- Updated ReadMe file for LinkedIn parameters.
- Currently only passing two default parameters, cookie name and the LinkedIn tracking tag.
- Implemented LinkedIn tracking based on original embed code provided by LinkedIn.