### PR TITLE
Remove iframe injection for GTM

### DIFF
--- a/src/services/google-tag-manager.js
+++ b/src/services/google-tag-manager.js
@@ -28,15 +28,6 @@ exports.addGoogleTagManager = (
     })(window, document, "script", dataLayerName, trackingId)
     /* eslint-enable */
 
-    const iframe = document.createElement(`iframe`)
-    iframe.key = `gatsby-plugin-gdpr-cookies-google-tagmanager-iframe`
-    iframe.src = `https://www.googletagmanager.com/ns.html?id=${trackingId}${environmentParamStr}`
-    iframe.height = 0
-    iframe.width = 0
-    iframe.style = `display: none; visibility: hidden`
-
-    document.body.insertBefore(iframe, document.body.firstChild)
-
     window.gatsbyPluginGDPRCookiesGoogleTagManagerAdded = true
 
     resolve(true)


### PR DESCRIPTION
There's probably no point in injecting the GTM iframe here. As per the [documentation](https://developers.google.com/tag-platform/tag-manager/web), this iframe is meant to be enclosed within a `<noscript>` tag so that GTM loads for visitors who have disabled Javascript. As this script runs in the browser anyways, it implies that it executes only for visitors who have Javascript enabled, so the iframe is redundant, and actually results in an extra network call.