### PR TITLE
Remove React as peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "peerDependencies": {
-    "gatsby": "^2.24.77 || ^3.0.0 || ^4.0.0",
-    "react": "^16.13.1 || ^17.0.1",
-    "react-dom": "^16.13.1 || ^17.0.1"
+    "gatsby": "^2.24.77 || ^3.0.0 || ^4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Plugin has no need to have a peerDependencies react/react-dom.

Removing the peerDependencies to react / react-dom would fix the issue users have while installing the Plugin.